### PR TITLE
Fix tox action running inside the GitHub actions framework

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        # python-version: ['3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - fix-tox
   pull_request:
     branches:
       - main
+      - fix-tox
 
 jobs:
   run-tox:

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -16,16 +16,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        # python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Check out repository
       uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: |
+            3.10
+            3.11
+            3.12
+            3.13
+            3.14
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - fix-tox
   pull_request:
     branches:
       - main
-      - fix-tox
 
 jobs:
   run-tox:
@@ -16,13 +14,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        # python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Check out repository
       uses: actions/checkout@v6
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python versions for testing
       uses: actions/setup-python@v7
       with:
         python-version: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = py310, py311, py312, py313, py314
-skip_missing_interpreters = false
+skip_missing_interpreters = true
 
 [testenv]
 # deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = py310, py311, py312, py313, py314
-skip_missing_interpreters = true
+skip_missing_interpreters = false
 
 [testenv]
 # deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, py313, py314, py315
+envlist = py310, py311, py312, py313, py314
+skip_missing_interpreters = false
 
 [testenv]
 # deps =


### PR DESCRIPTION
With this PR, the Github Actions workflow for automatically running `tox` will work again.

Removed end-of-life versions of Python and also removed a version that is not released yet (3.15).

The tox runner is called for every combination of OS+Python Version individually now.